### PR TITLE
ensure that config has new API port

### DIFF
--- a/examples-website/server/config/init.js
+++ b/examples-website/server/config/init.js
@@ -24,7 +24,7 @@ module.exports = class App {
     init(express, bodyParser, favicon) {
 
         const app = express()
-            .set('port', process.env.PORT || 3001)
+            .set('port', process.env.API_PORT || 3001)
             .set('views', path.join(__dirname, '/../views'))
             .set('view engine', 'jade')
             .use(express.static('app/public'))


### PR DESCRIPTION
I didn't realize my last pull request would keep getting updated as I pushed new versions of master.

So my last 2 major commits were accepted which is cool but I just wanted to point out 3 things that I missed in my last commit.

1.
When you go to deploy to heroku, there is a new ENV var for the API_PORT so now we have both:
* process.env.PORT       
* process.env.API_PORT
If you could this prop in heroku, that would be sweet. Also see demodata.js line 38 to see where its looks for local or remote based on the environment. 

2.
Sticky example has duplicate key issue and throws an error in the console. I'll fix this next commit I think... 
 
3. 
Dragging Columns is broken
http://react-redux-grid.herokuapp.com/#complex I see it's working here so I'll try to fix that too

4. 
I used a css file to override some CSS values using !important - see ExampleGridContainer.css - I know that's not the best process so perhaps you have some thoughts on managing CSS conflicts between Bootstrap, React-Redux-Grid and then the developer's custom CSS - but it seems to be working as a bandaid for now.

 